### PR TITLE
Added import to compile it under opencv2.4+linux

### DIFF
--- a/grouping/source/gpb_src/src/math/geometry/seg_intersect.cc
+++ b/grouping/source/gpb_src/src/math/geometry/seg_intersect.cc
@@ -109,6 +109,7 @@ seg_intersect::seg_intersect(
    /* create comparison functor for event queue */
    class event_compare : public comparable_functor<vrtx> {
    public:
+      event_compare(){};
       int operator()(const vrtx& v0, const vrtx& v1) const {
          return v0.p.compare_to(v1.p);
       }

--- a/grouping/source/gpb_src/src/math/geometry/triangulation.cc
+++ b/grouping/source/gpb_src/src/math/geometry/triangulation.cc
@@ -192,6 +192,7 @@ auto_ptr<triangulation> triangulation::delaunay(
    /* sort vertices in lexicographic order */
    class vrtx_compare : public comparable_functor<vrtx> {
    public:
+      vrtx_compare(){};
       int operator()(const vrtx& v0, const vrtx& v1) const {
          return v0.p.compare_to(v1.p);
       }

--- a/grouping/source/gpb_src/src/math/libraries/lib_image.cc
+++ b/grouping/source/gpb_src/src/math/libraries/lib_image.cc
@@ -6139,6 +6139,7 @@ void lib_image::contour_set::subdivide_global() {
    /* create comparison functor for sorting edges by vertex id */
    class edge_compare : public comparable_functor<contour_edge> {
    public:
+      edge_compare(){};
       int operator()(const contour_edge& e0, const contour_edge& e1) const {
          bool v0_cmp = (e0.vertex_start->id < e0.vertex_end->id);
          bool v1_cmp = (e1.vertex_start->id < e1.vertex_end->id);

--- a/grouping/source/opencv_gpb/src/watershed.cpp
+++ b/grouping/source/opencv_gpb/src/watershed.cpp
@@ -37,6 +37,7 @@
 #include <list>
 
 #include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/imgproc/types_c.h>
 
 #include "watershed.h"
 


### PR DESCRIPTION
The types_c.h is not being included anymore on imgproc.hpp,
probably due to OpenCV's shift onto C++ in the recent years.
Included a line to make it possible to compile under linux
using OpenCV 2.4

Signed-off-by: Luiz Carlos Cavalcanti <luiz.cavalcanti@indt.org.br>